### PR TITLE
feat(amazonq): send code issues to plugin to populate the code issues panel

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1298,6 +1298,15 @@ export class AgenticChatController implements ChatHandlers {
                         break
                     case QCodeReview.toolName:
                         // no need to write tool result for code review, this is handled by model via chat
+                        const qCodeReviewJson = JSON.parse(JSON.stringify(result))
+                        await chatResultStream.writeResultBlock({
+                            type: 'tool',
+                            messageId: toolUse.toolUseId + '_findings',
+                            body: JSON.stringify({
+                                filePath: JSON.parse(JSON.stringify(toolUse.input))['fileLevelArtifacts'][0]['path'],
+                                issues: JSON.parse(qCodeReviewJson['result']['findings']),
+                            }),
+                        })
                         break
                     // — DEFAULT ⇒ MCP tools
                     default:

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1302,10 +1302,7 @@ export class AgenticChatController implements ChatHandlers {
                         await chatResultStream.writeResultBlock({
                             type: 'tool',
                             messageId: toolUse.toolUseId + '_findings',
-                            body: JSON.stringify({
-                                filePath: JSON.parse(JSON.stringify(toolUse.input))['fileLevelArtifacts'][0]['path'],
-                                issues: JSON.parse(qCodeReviewJson['result']['findings']),
-                            }),
+                            body: qCodeReviewJson['result']['findings'],
                         })
                         break
                     // — DEFAULT ⇒ MCP tools

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -94,7 +94,7 @@ import {
     isUsageLimitError,
     isNullish,
 } from '../../shared/utils'
-import { HELP_MESSAGE, loadingMessage } from '../chat/constants'
+import { HELP_MESSAGE, loadingMessage, findingsSuffix } from '../chat/constants'
 import { TelemetryService } from '../../shared/telemetry/telemetryService'
 import {
     AmazonQError,
@@ -1301,7 +1301,7 @@ export class AgenticChatController implements ChatHandlers {
                         const qCodeReviewJson = JSON.parse(JSON.stringify(result))
                         await chatResultStream.writeResultBlock({
                             type: 'tool',
-                            messageId: toolUse.toolUseId + '_findings',
+                            messageId: toolUse.toolUseId + findingsSuffix,
                             body: qCodeReviewJson['result']['findings'],
                         })
                         break

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/qCodeReview.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/qCodeReview.ts
@@ -169,7 +169,30 @@ export class QCodeReview {
 
                 let validatedFindings: any[] = []
                 if (findingsResponse.codeAnalysisFindings) {
-                    validatedFindings = Q_FINDINGS_SCHEMA.parse(JSON.parse(findingsResponse.codeAnalysisFindings))
+                    const intermediateFindings = Q_FINDINGS_SCHEMA.parse(
+                        JSON.parse(findingsResponse.codeAnalysisFindings)
+                    )
+
+                    validatedFindings = intermediateFindings.map((issue: any) => {
+                        return {
+                            startLine: issue.startLine - 1 >= 0 ? issue.startLine - 1 : 0,
+                            endLine: issue.endLine,
+                            comment: `${issue.title.trim()}: ${issue.description.text.trim()}`,
+                            title: issue.title,
+                            description: issue.description,
+                            detectorId: issue.detectorId,
+                            detectorName: issue.detectorName,
+                            findingId: issue.findingId,
+                            ruleId: issue.ruleId,
+                            relatedVulnerabilities: issue.relatedVulnerabilities,
+                            severity: issue.severity,
+                            recommendation: issue.remediation.recommendation,
+                            suggestedFixes: issue.remediation.suggestedFixes,
+                            scanJobId: jobId,
+                            language: programmingLanguage,
+                            autoDetected: false,
+                        }
+                    })
                 }
 
                 this.logging.info(`Parsed findings: ${JSON.stringify(validatedFindings)}`)

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/qCodeReview.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/qCodeReview.ts
@@ -191,6 +191,7 @@ export class QCodeReview {
                             scanJobId: jobId,
                             language: programmingLanguage,
                             autoDetected: false,
+                            filePath: issue.filePath,
                         }
                     })
                 }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/qCodeReviewSchemas.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/qCodeReviewSchemas.ts
@@ -115,6 +115,10 @@ export const Q_FINDING_SCHEMA = z.object({
     startLine: z.number(),
     title: z.string(),
     findingContext: z.string().nullable().optional(),
+    detectorId: z.string().optional(),
+    detectorName: z.string().optional(),
+    ruleId: z.string().optional(),
+    suggestedFixes: z.array(z.string().optional()).optional(),
 })
 
 /**

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/constants.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/constants.ts
@@ -83,3 +83,5 @@ export const loadingMessage: ChatMessage = {
     // TODO: Add this to runtimes
     type: 'answer-stream',
 }
+
+export const findingsSuffix = '_qCodeScanFindings'


### PR DESCRIPTION
## Problem
Need to communicate findings back to the plugin to store in Code Issues panel

## Solution
send a message back to the plugin with a message id ending with "_findings" so it can be intercepted without posting to the chat
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
